### PR TITLE
fixed minor error in printing warnings for analyze_gradients

### DIFF
--- a/polygnn_trainer/utils.py
+++ b/polygnn_trainer/utils.py
@@ -154,7 +154,7 @@ def analyze_gradients(named_parameters, allow_errors=False):
                 layers.append(n)
             except Exception as e:
                 warnings.warn(
-                    "The parameter {n} has the following invalid gradient:\n{p.grad}."
+                    f"The parameter {n} has the following invalid gradient:\n{p.grad}."
                 )
                 if allow_errors:
                     pass


### PR DESCRIPTION
The warning wasn't printing the right way, instead of printing the values of n and p.grad it printed them as strings.